### PR TITLE
refactor(home): Move relatorios component to Home

### DIFF
--- a/src/components/CardAscDecInfo.tsx
+++ b/src/components/CardAscDecInfo.tsx
@@ -26,7 +26,7 @@ const InfoButton: React.FC<InfoButtonProps> = ({
       </button>
 
       {showInfo && (
-        <div className="absolute z-10 mt-2 p-4 w-96 bg-white border border-gray-300 rounded shadow-lg right-0">
+        <div className="absolute z-10 bottom-full mt-2 p-4 w-96 bg-white border border-gray-300 rounded shadow-lg right-0">
           <p className="text-sm text-gray-800">{message}</p>
           <img
             src={imageSrc}

--- a/src/pages/DataInsights.tsx
+++ b/src/pages/DataInsights.tsx
@@ -2,7 +2,6 @@ import FilteredDataBarChart from "../components/RemovedEntriesChart"
 import SidebarLayout from "../components/Sidebar"
 import { GlobalYearStateProvider } from "../context/GlobalYearStateContext"
 import { ExportContextProvider } from "../context/ExportContext";
-import CardAscDec from "../components/CardAscDec";
 
 const sampleData = [
   { label: 'Unid. medida inválida', removedCount: 47 },
@@ -24,7 +23,6 @@ const DataInsights = () => {
       <GlobalYearStateProvider>
         <SidebarLayout>
           <div className="p-6 md:p-10 max-w-4xl mx-auto text-gray-800">
-            <CardAscDec />
             <h1 className="text-2xl font-semibold mb-4 text-center">Relatório de Linhas Removidas</h1>
             <p className="mb-4 text-lg text-justify">
               Esta seção apresenta insights sobre a qualidade e consistência dos dados utilizados na plataforma Alfalog, com foco na identificação de informações descartadas durante o processo de normalização.

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,7 +1,7 @@
 import SidebarLayout from "../components/Sidebar";
 import { ExportContextProvider } from "../context/ExportContext";
 import { GlobalYearStateProvider } from "../context/GlobalYearStateContext";
-
+import CardAscDec from "../components/CardAscDec";
 
 const Home = () => {
   return (
@@ -61,6 +61,7 @@ const Home = () => {
                   <p className="text-gray-600">Compare o desempenho de diferentes estados ao longo dos anos.</p>
                 </div>
               </div>
+              <CardAscDec />
             </div>
           </SidebarLayout>
         </GlobalYearStateProvider>


### PR DESCRIPTION
This change relocates the CardAscDec component from the DataInsights (relatórios) page to the Home.